### PR TITLE
 Move assignments and ctors should be noexcept 

### DIFF
--- a/headers/utils-cpp/copy_move.h
+++ b/headers/utils-cpp/copy_move.h
@@ -20,8 +20,8 @@
    classname &operator=(const classname &) = default
 
 #define DEFAULT_MOVE(classname)       \
-   classname(classname &&) = default; \
-   classname &operator=(classname &&) = default
+   classname(classname &&) noexcept = default; \
+   classname &operator=(classname &&) noexcept = default
 
 #define DEFAULT_COPY_MOVE(classname) \
    DEFAULT_COPY(classname);          \


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/performance/noexcept-move-constructor.html