### PR TITLE
Attributes: Fix Compiler-Detection

### DIFF
--- a/headers/utils-cpp/attributes.h
+++ b/headers/utils-cpp/attributes.h
@@ -9,7 +9,7 @@
   #endif
 #endif
 // gcc
-#if !defined(UTIL_CPP_ATTR_UB) && defined(__SANITIZE_ADDRESS__)
+#if !defined(UTIL_CPP_ATTR_UB) && defined(__GNUC__) 
     #define UTIL_CPP_ATTR_UB __attribute__((no_sanitize("undefined")))
 #endif
 // fallback


### PR DESCRIPTION
Unfortunately GCC has no define for the UB-San and __SANITIZE_ADDRESS__ was the wrong macro for the UB-San and is also set by MSVC.